### PR TITLE
Add support for Ubuntu 14.04 (Trusty)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-zookeeper_version: "3.4.5+cdh5.2.0+82-1.cdh5.2.0.p0.40~precise-cdh5.2.0"
+zookeeper_version: "3.4.5+cdh5.2.0+82-1.cdh5.2.0.p0.40~trusty-cdh5.2.0"
 zookeeper_conf_dir: "/etc/zookeeper/conf"
 zookeeper_data_dir: "/var/lib/zookeeper"
 zookeeper_max_client_connections: 50

--- a/examples/Vagrantfile
+++ b/examples/Vagrantfile
@@ -15,7 +15,7 @@ if [ "up", "provision" ].include?(ARGV.first) &&
 end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "ubuntu/precise64"
+  config.vm.box = "ubuntu/trusty64"
 
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "site.yml"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,8 +8,9 @@ galaxy_info:
   platforms:
   - name: Ubuntu
     versions:
+    - trusty
     - precise
   categories:
   - database
 dependencies:
-  - { role: "azavea.java", java_version: "7u71-2.5.3-0ubuntu0.12.04.1" }
+  - { role: "azavea.java", java_version: "7u71-2.5.3-0ubuntu0.14.04.1" }

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,9 @@
   apt_repository: repo="deb [arch=amd64] http://archive.cloudera.com/cdh5/ubuntu/{{ ansible_distribution_release }}/amd64/cdh {{ ansible_distribution_release }}-cdh5 contrib"
                   state=present
 
+- name: Pin Cloudera APT repositories
+  template: src=cdh5.j2 dest=/etc/apt/preferences.d/cdh5
+
 - name: Install Zookeeper
   apt: pkg=zookeeper-server={{ zookeeper_version }} state=present
 

--- a/templates/cdh5.j2
+++ b/templates/cdh5.j2
@@ -1,0 +1,7 @@
+Package: *
+Pin: release n={{ ansible_distribution_release }}
+Pin-Priority: 100
+
+Package: *
+Pin: release n={{ ansible_distribution_release }}-cdh5
+Pin-Priority: 600


### PR DESCRIPTION
In addition, this changeset gives the Cloudera repository priority over the default Ubuntu repositories for cases where package names match and we want the Cloudera packages to win.
