### PR TITLE
Add variable for Cloudera distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ An Ansible role for installing [Apache Zookeeper](http://zookeeper.apache.org).
 ## Role Variables
 
 - `zookeeper_version` - Zookeeper version.
+- `zookeeper_cloudera_distribution` - Cloudera distribution version (default: `cdh5.4`)
 - `zookeeper_conf_dir` - Configuration directory for Zookeeper (default: `/etc/zookeeper/conf`)
 - `zookeeper_data_dir`: Data directory for Zookeeper (default: `/var/lib/zookeeper`)
 - `zookeeper_max_client_connections` - Maximum number of client connections (default: `50`)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
-zookeeper_version: "3.4.5+cdh5.3.*"
+zookeeper_version: "3.4.5+cdh5.4.*"
+zookeeper_cloudera_distribution: "cdh5.4"
 zookeeper_conf_dir: "/etc/zookeeper/conf"
 zookeeper_data_dir: "/var/lib/zookeeper"
 zookeeper_max_client_connections: 50

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
            state=present
 
 - name: Configure the Cloudera APT repositories
-  apt_repository: repo="deb [arch=amd64] http://archive.cloudera.com/cdh5/ubuntu/{{ ansible_distribution_release }}/amd64/cdh {{ ansible_distribution_release }}-cdh5 contrib"
+  apt_repository: repo="deb [arch=amd64] http://archive.cloudera.com/cdh5/ubuntu/{{ ansible_distribution_release }}/amd64/cdh {{ ansible_distribution_release }}-{{ zookeeper_cloudera_distribution }} contrib"
                   state=present
 
 - name: Pin Cloudera APT repositories


### PR DESCRIPTION
This changeset adds a `zookeeper_cloudera_distribution` variable that is used to determine which Cloudera package distribution channel to use.

In addition, setting `zookeeper_cloudera_distribution` to `cdh5` will automatically pull in major Cloudera repository changes (`cdh5.3` -> `cdh5.4`).